### PR TITLE
Add support for monitor failed exctractions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,19 @@ Usage
 - Configure the report in the publisher control panel.
 
 
+Failed extraction monitoring
+----------------------------
+
+When the publisher is set up with an asynchronous extraction queue (e.g. with redis),
+the extraction may break.
+This is possible because the extraction is asynchronous and thus not in the same
+transaction as the publisher job is created.
+Therefore creating the publisher job may work, but executing the extraction job may fail.
+
+For mitigating that problem we are monitoring the jobs and warn whenever a job has still
+a 0-sized job file and the job file is older than the configured threshold.
+
+
 
 Links
 -----

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 2.0b1 (unreleased)
 ------------------
 
+- Add support for monitor failed exctractions. [jone]
 - Drop Plone 4.2 support. [jone]
-
 - Drop compatibility with Plone 4.1.
   Add compatibility with Plone 4.3. [mbaechtold]
 

--- a/ftw/publisher/monitor/adapters.py
+++ b/ftw/publisher/monitor/adapters.py
@@ -19,9 +19,10 @@ class MonitorNotifier(object):
         self.config = None
         self.queue = None
 
-    def __call__(self, config, queue):
+    def __call__(self, config, queue, reason):
         self.config = config
         self.queue = queue
+        self.reason = reason
         self.send_email()
 
     def send_email(self):
@@ -61,7 +62,8 @@ class MonitorNotifier(object):
 
         data = {'jobs_in_queue': self.queue.countJobs(),
                 'subject': self.get_subject(),
-                'portal': self.context}
+                'portal': self.context,
+                'reason': self.reason}
         return data
 
     def render_template(self):

--- a/ftw/publisher/monitor/browser/config.py
+++ b/ftw/publisher/monitor/browser/config.py
@@ -65,6 +65,15 @@ class MonitorConfigurationAdapter(SchemaAdapterBase, object):
 
     threshold = property(get_threshold, set_threshold)
 
+    def get_max_extraction_duration_seconds(self):
+        return self.storage.get('max_extraction_duration_seconds', 3 * 60)
+
+    def set_max_extraction_duration_seconds(self, value):
+        self.storage['max_extraction_duration_seconds'] = int(value)
+
+    max_extraction_duration_seconds = property(get_max_extraction_duration_seconds,
+                                               set_max_extraction_duration_seconds)
+
 
 class MonitorConfigurationForm(FieldsetsEditForm):
     """Monitor configuration form

--- a/ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt
+++ b/ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt
@@ -10,10 +10,7 @@
         <a tal:attributes="href options/portal/absolute_url"
            tal:content="options/portal/absolute_url" />
 
-        <p i18n:translate="warning_mail_message">
-            The amount of jobs in the publisher queue of the senders host
-            reached the threshold. The queue may be blocked!
-        </p>
+        <p class="reason" tal:content="options/reason" />
 
         <table>
             <tr>

--- a/ftw/publisher/monitor/handlers.py
+++ b/ftw/publisher/monitor/handlers.py
@@ -1,7 +1,9 @@
 from ftw.publisher.monitor import _
 from ftw.publisher.monitor.interfaces import IMonitorConfigurationSchema
 from ftw.publisher.monitor.interfaces import IMonitorNotifier
+from time import time
 from zope.component import getAdapter
+import os.path
 
 
 def invoke_notification(obj, event):
@@ -13,9 +15,45 @@ def invoke_notification(obj, event):
     if not config.enabled or not len(config.get_receivers()):
         return
 
-    amount_of_jobs = event.queue.countJobs()
+    monitor_queue_length(obj, event.queue, config)
+    monitor_failed_extractions(obj, event.queue, config)
+
+
+def monitor_queue_length(obj, queue, config):
+    """Verify that the queue length does not exceed the the configured threshold.
+    If it exceeds, notify the subscribers.
+    """
+    amount_of_jobs = queue.countJobs()
     if amount_of_jobs >= config.threshold:
         reason = _(u'warning_mail_message',
                    default=u'The amount of jobs in the publisher queue of the'
                    u' senders host reached the threshold. The queue may be blocked!')
-        return getAdapter(obj, IMonitorNotifier)(config, event.queue, reason)
+        getAdapter(obj, IMonitorNotifier)(config, queue, reason)
+
+
+def monitor_failed_extractions(obj, queue, config):
+    """When the publisher is configured to exctract asynchronously, the extraction
+    may fail. We monitor that by making sure that empty job files are not older than
+    a threshold.
+    """
+    now = time()
+    max_age = config.max_extraction_duration_seconds
+    for job in queue.getJobs():
+        # size -1 means job was already executed
+        # size 0  means job is awating async extraction
+        # size >1 means job is ready
+        if job.getSize() != 0:
+            # we are only interested in jobs awaiting extraction
+            continue
+
+        try:
+            age = now - os.path.getmtime(job.dataFile)
+        except OSError:
+            continue
+
+        if age > max_age:
+            reason = _(u'warning_mail_message_extraction_problem',
+                       default=u'Extraction of a publisher job failed for ${age} seconds.'
+                       u' This will probably jam the queue.',
+                       mapping={'age': int(age)})
+            return getAdapter(obj, IMonitorNotifier)(config, queue, reason)

--- a/ftw/publisher/monitor/handlers.py
+++ b/ftw/publisher/monitor/handlers.py
@@ -1,3 +1,4 @@
+from ftw.publisher.monitor import _
 from ftw.publisher.monitor.interfaces import IMonitorConfigurationSchema
 from ftw.publisher.monitor.interfaces import IMonitorNotifier
 from zope.component import getAdapter
@@ -14,4 +15,7 @@ def invoke_notification(obj, event):
 
     amount_of_jobs = event.queue.countJobs()
     if amount_of_jobs >= config.threshold:
-        return getAdapter(obj, IMonitorNotifier)(config, event.queue)
+        reason = _(u'warning_mail_message',
+                   default=u'The amount of jobs in the publisher queue of the'
+                   u' senders host reached the threshold. The queue may be blocked!')
+        return getAdapter(obj, IMonitorNotifier)(config, event.queue, reason)

--- a/ftw/publisher/monitor/interfaces.py
+++ b/ftw/publisher/monitor/interfaces.py
@@ -30,3 +30,14 @@ class IMonitorConfigurationSchema(Interface):
                       'than this value, a alert will be sent.'),
         default=100,
         required=True)
+
+    max_extraction_duration_seconds = schema.Int(
+        title=_(u'label_max_extraction_duration_seconds',
+                default=u'Maximum extraction duration (seconds)'),
+        description=_(u'help_threshold',
+                      default=u'If the asynchronous extraction takes longer than this'
+                      u' amount of seconds, it is considered to not work.'
+                      u' Candidates are 0-sized jobs, measurement is the age of the'
+                      u' modification time of the data file.'),
+        default=3 * 60,
+        required=True)

--- a/ftw/publisher/monitor/locales/de/LC_MESSAGES/ftw.publisher.monitor.po
+++ b/ftw/publisher/monitor/locales/de/LC_MESSAGES/ftw.publisher.monitor.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-15 13:34+0000\n"
-"PO-Revision-Date: 2010-11-29 13:28+0100\n"
+"POT-Creation-Date: 2017-11-15 14:09+0000\n"
+"PO-Revision-Date: 2017-11-15 15:10+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -12,22 +12,22 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #. Default: "Cancel"
-#: ./ftw/publisher/monitor/browser/config.py:102
+#: ./ftw/publisher/monitor/browser/config.py:111
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Save"
-#: ./ftw/publisher/monitor/browser/config.py:87
+#: ./ftw/publisher/monitor/browser/config.py:96
 msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/publisher/monitor/browser/config.py:92
+#: ./ftw/publisher/monitor/browser/config.py:101
 msgid "error_invalid_addresses"
 msgstr "Mindestens eine der angegebenen E-Mail Adressen ist ungültig."
 
 #. Default: "Publisher monitor configuration"
-#: ./ftw/publisher/monitor/browser/config.py:77
+#: ./ftw/publisher/monitor/browser/config.py:86
 msgid "help_monitor_configuration"
 msgstr "Konfiguration der Überwachung der Publisher-Warteschleife"
 
@@ -41,8 +41,13 @@ msgstr "Geben Sie eine E-Mail Adresse pro Zeile an."
 msgid "help_threshold"
 msgstr "Wenn die Gröss der Warteschleife diesen Wert überschreitet, wird die Benachrichtigung ausgelöst."
 
+#. Default: "Maximum extraction duration (seconds)"
+#: ./ftw/publisher/monitor/interfaces.py:35
+msgid "label_max_extraction_duration_seconds"
+msgstr "Maximale Dauer für Datenextraktion (Sekunden)"
+
 #. Default: "Monitor configuration"
-#: ./ftw/publisher/monitor/browser/config.py:75
+#: ./ftw/publisher/monitor/browser/config.py:84
 msgid "label_monitor_configuration"
 msgstr "Konfiguration Überwachung"
 
@@ -77,7 +82,12 @@ msgid "mail_th_jobs_in_queue"
 msgstr "Anzahl Aufträge in der Warteschleife:"
 
 #. Default: "The amount of jobs in the publisher queue of the senders host reached the threshold. The queue may be blocked!"
-#: ./ftw/publisher/monitor/handlers.py:18
+#: ./ftw/publisher/monitor/handlers.py:28
 msgid "warning_mail_message"
 msgstr "Die Anzahl wartender Aufträge in der Warteschleife hat den Grenzwert überschritten. Möglicherweise liegt ein Problem mit der Warteschleife vor."
+
+#. Default: "Extraction of a publisher job failed for ${age} seconds. This will probably jam the queue."
+#: ./ftw/publisher/monitor/handlers.py:55
+msgid "warning_mail_message_extraction_problem"
+msgstr "Die Extraktion eines Publisher-Jobs hat nach ${age} Sekunden nicht geklappt. Dies verstopft vermutlich die Warteschleife."
 

--- a/ftw/publisher/monitor/locales/de/LC_MESSAGES/ftw.publisher.monitor.po
+++ b/ftw/publisher/monitor/locales/de/LC_MESSAGES/ftw.publisher.monitor.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-11-02 16:27+0000\n"
+"POT-Creation-Date: 2017-11-15 13:34+0000\n"
 "PO-Revision-Date: 2010-11-29 13:28+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,7 +10,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
 #. Default: "Cancel"
 #: ./ftw/publisher/monitor/browser/config.py:102
@@ -68,16 +67,17 @@ msgid "link_monitor_configuration"
 msgstr "Konfiguration Überwachung"
 
 #. Default: "Publisher monitor warning: ${site}"
-#: ./ftw/publisher/monitor/adapters.py:54
+#: ./ftw/publisher/monitor/adapters.py:55
 msgid "mail_subject"
 msgstr "Warnung Publisher Überwachung auf ${site}"
 
 #. Default: "Jobs in the queue:"
-#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:20
+#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:17
 msgid "mail_th_jobs_in_queue"
 msgstr "Anzahl Aufträge in der Warteschleife:"
 
 #. Default: "The amount of jobs in the publisher queue of the senders host reached the threshold. The queue may be blocked!"
-#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:13
+#: ./ftw/publisher/monitor/handlers.py:18
 msgid "warning_mail_message"
 msgstr "Die Anzahl wartender Aufträge in der Warteschleife hat den Grenzwert überschritten. Möglicherweise liegt ein Problem mit der Warteschleife vor."
+

--- a/ftw/publisher/monitor/locales/ftw.publisher.monitor.pot
+++ b/ftw/publisher/monitor/locales/ftw.publisher.monitor.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-11-02 16:27+0000\n"
+"POT-Creation-Date: 2017-11-15 13:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,10 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.publisher.monitor\n"
 
 #. Default: "Cancel"
 #: ./ftw/publisher/monitor/browser/config.py:102
@@ -73,17 +70,17 @@ msgid "link_monitor_configuration"
 msgstr ""
 
 #. Default: "Publisher monitor warning: ${site}"
-#: ./ftw/publisher/monitor/adapters.py:54
+#: ./ftw/publisher/monitor/adapters.py:55
 msgid "mail_subject"
 msgstr ""
 
 #. Default: "Jobs in the queue:"
-#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:20
+#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:17
 msgid "mail_th_jobs_in_queue"
 msgstr ""
 
 #. Default: "The amount of jobs in the publisher queue of the senders host reached the threshold. The queue may be blocked!"
-#: ./ftw/publisher/monitor/browser/mail_templates/notification_mail_html.pt:13
+#: ./ftw/publisher/monitor/handlers.py:18
 msgid "warning_mail_message"
 msgstr ""
 

--- a/ftw/publisher/monitor/locales/ftw.publisher.monitor.pot
+++ b/ftw/publisher/monitor/locales/ftw.publisher.monitor.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-15 13:34+0000\n"
+"POT-Creation-Date: 2017-11-15 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,22 +15,22 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 
 #. Default: "Cancel"
-#: ./ftw/publisher/monitor/browser/config.py:102
+#: ./ftw/publisher/monitor/browser/config.py:111
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Save"
-#: ./ftw/publisher/monitor/browser/config.py:87
+#: ./ftw/publisher/monitor/browser/config.py:96
 msgid "button_save"
 msgstr ""
 
 #. Default: "At least one of the defined addresses are not valid."
-#: ./ftw/publisher/monitor/browser/config.py:92
+#: ./ftw/publisher/monitor/browser/config.py:101
 msgid "error_invalid_addresses"
 msgstr ""
 
 #. Default: "Publisher monitor configuration"
-#: ./ftw/publisher/monitor/browser/config.py:77
+#: ./ftw/publisher/monitor/browser/config.py:86
 msgid "help_monitor_configuration"
 msgstr ""
 
@@ -44,8 +44,13 @@ msgstr ""
 msgid "help_threshold"
 msgstr ""
 
+#. Default: "Maximum extraction duration (seconds)"
+#: ./ftw/publisher/monitor/interfaces.py:35
+msgid "label_max_extraction_duration_seconds"
+msgstr ""
+
 #. Default: "Monitor configuration"
-#: ./ftw/publisher/monitor/browser/config.py:75
+#: ./ftw/publisher/monitor/browser/config.py:84
 msgid "label_monitor_configuration"
 msgstr ""
 
@@ -80,7 +85,12 @@ msgid "mail_th_jobs_in_queue"
 msgstr ""
 
 #. Default: "The amount of jobs in the publisher queue of the senders host reached the threshold. The queue may be blocked!"
-#: ./ftw/publisher/monitor/handlers.py:18
+#: ./ftw/publisher/monitor/handlers.py:28
 msgid "warning_mail_message"
+msgstr ""
+
+#. Default: "Extraction of a publisher job failed for ${age} seconds. This will probably jam the queue."
+#: ./ftw/publisher/monitor/handlers.py:55
+msgid "warning_mail_message_extraction_problem"
 msgstr ""
 

--- a/ftw/publisher/monitor/tests/test_config.py
+++ b/ftw/publisher/monitor/tests/test_config.py
@@ -70,6 +70,7 @@ class TestConfig(TestCase):
                 'my@test.local',
                 'foo@bar.com'))
         self.browser.getControl(name='form.threshold').value = '75'
+        self.browser.getControl(name='form.max_extraction_duration_seconds').value = '777'
 
         self.browser.getControl('Save').click()
         self.assertEqual(self.browser.url, self.config_url)
@@ -80,6 +81,7 @@ class TestConfig(TestCase):
         self.assertEqual(config.get_receivers(), [
                 'my@test.local', 'foo@bar.com'])
         self.assertEqual(config.threshold, 75)
+        self.assertEqual(config.max_extraction_duration_seconds, 777)
 
     def test_receiver_mail_validation(self):
         self.assertEqual(

--- a/ftw/publisher/monitor/tests/test_eventhandler.py
+++ b/ftw/publisher/monitor/tests/test_eventhandler.py
@@ -70,7 +70,7 @@ class TestEventhandler(MockTestCase):
         self.stub_current_queue_length(3)
         event = self.create_dummy(queue=self.queue)
 
-        self.expect(self.notifier(ANY, ANY))
+        self.expect(self.notifier(ANY, ANY, ANY))
         self.replay()
 
         invoke_notification(self.portal, event)
@@ -79,7 +79,7 @@ class TestEventhandler(MockTestCase):
         self.config.set_threshold(2)
         self.stub_current_queue_length(3)
 
-        self.expect(self.notifier(ANY, ANY))
+        self.expect(self.notifier(ANY, ANY, ANY))
         self.replay()
 
         self.portal.unrestrictedTraverse('@@publisher.executeQueue')()
@@ -90,7 +90,7 @@ class TestEventhandler(MockTestCase):
 
         self.config.set_enabled(False)
 
-        self.expect(self.notifier(ANY, ANY)).count(0)
+        self.expect(self.notifier(ANY, ANY, ANY)).count(0)
         self.replay()
 
         self.portal.unrestrictedTraverse('@@publisher.executeQueue')()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'mocker',
     'zope.configuration',
     'plone.testing',
+    'ftw.testbrowser',
     'ftw.testing',
     'plone.app.testing',
     ]


### PR DESCRIPTION
When the publisher is set up with an asynchronous extraction queue (e.g. with redis),
the extraction may break.
This is possible because the extraction is asynchronous and thus not in the same
transaction as the publisher job is created.
Therefore creating the publisher job may work, but executing the extraction job may fail.

For mitigating that problem we are monitoring the jobs and warn whenever a job has still
a 0-sized job file and the job file is older than the configured threshold.
