### PR TITLE
Fix sending actual emails with plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix sending actual emails with plone 5. [mathias.leimgruber]
 
 
 2.0.1 (2020-08-04)

--- a/ftw/publisher/monitor/tests/test_mailing.py
+++ b/ftw/publisher/monitor/tests/test_mailing.py
@@ -1,13 +1,14 @@
 from Acquisition import aq_base
-from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.publisher.monitor.interfaces import IMonitorConfigurationSchema
 from ftw.publisher.monitor.tests import MockTestCase
+from ftw.publisher.monitor.utils import IS_PLONE_5
 from ftw.publisher.sender.interfaces import IQueue
 from ftw.testbrowser import browsing
 from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
 from time import time
 from zope.component import getUtility
 import os
@@ -32,9 +33,17 @@ class TestEmailNotification(MockTestCase):
         self.config.receivers = [u'hugo@boss.com']
 
         # configure mail settings
-        properties_tool = getToolByName(self.portal, 'portal_properties')
-        properties_tool.email_from_name = 'Plone'
-        properties_tool.email_from_address = 'test@plone.org'
+
+        if IS_PLONE_5:
+            from Products.CMFPlone.interfaces.controlpanel import IMailSchema
+            registry = getUtility(IRegistry)
+            mail_settings = registry.forInterface(IMailSchema, prefix='plone')
+            mail_settings.email_from_name = u'Plone'
+            mail_settings.email_from_address = 'test@plone.org'
+        else:
+            properties_tool = getToolByName(self.portal, 'portal_properties')
+            properties_tool.email_from_name = 'Plone'
+            properties_tool.email_from_address = 'test@plone.org'
 
         # patch MailHost
         self.mail_host = self.stub()

--- a/ftw/publisher/monitor/utils.py
+++ b/ftw/publisher/monitor/utils.py
@@ -1,4 +1,8 @@
+from plone.registry.interfaces import IRegistry
+import pkg_resources
 import re
+
+IS_PLONE_5 = pkg_resources.get_distribution('Plone').version >= '5'
 
 
 def email_addresses_validator(values):


### PR DESCRIPTION
Test was not good enough for plone5

The properties tool is still there but does not get configured anymore within plone 5. The though did.
I implemented the plone 5 variation of getting the senders from name and mail.

Info:
- The email address is a ascii field
- The name a textline (unicode)