### PR TITLE
Fix charset for mail body.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- New Mailhost needs a explicit charset. [mathias.leimgruber]
 
 
 2.0.2 (2020-09-01)

--- a/ftw/publisher/monitor/adapters.py
+++ b/ftw/publisher/monitor/adapters.py
@@ -60,7 +60,7 @@ class MonitorNotifier(object):
 
         for rcpt in self.config.receivers:
             msg['To'] = rcpt
-            mh.send(msg, mto=rcpt, mfrom=from_addr, subject=subject, immediate=True)
+            mh.send(msg, mto=rcpt, mfrom=from_addr, subject=subject, charset='utf-8', immediate=True)
 
     def get_subject(self):
         return _(u'mail_subject',


### PR DESCRIPTION
We have a umlaut in the body if the site runs in german 😏 